### PR TITLE
fix assets inclusion

### DIFF
--- a/advanced-wplink.php
+++ b/advanced-wplink.php
@@ -41,7 +41,7 @@ if(version_compare(PHP_VERSION, '5.3', '<')) {
 		'version'	=> '0',
 
 		'dirname'	=> dirname(plugin_basename(__FILE__)),
-		'dir'		=> plugins_url('/advanced-wplink'),
+		'dir'		=> plugins_url(plugin_basename(__DIR__)),
 		'plugin'	=> plugin_basename(__FILE__)
 	);
 

--- a/class/Editor.php
+++ b/class/Editor.php
@@ -1,11 +1,14 @@
 <?php
 namespace NM\AdvancedWPLink;
 class Editor {
-	
+
 	public function __construct(){
-		add_action( 'admin_init', 			array($this,'admin_editor_style'));
-		add_action( 'admin_head',			array($this,'admin_head_js'));
-		add_action( 'admin_enqueue_scripts',array($this,'scripts'), 999);
+		add_action( 'admin_init', array($this,'admin_editor_style'));
+		add_action( 'admin_head', array($this,'admin_head_js'));
+
+		// it is over 999999! higher than aioseo
+		add_action( 'wp_enqueue_editor', array($this,'scripts'), 1000000);
+		add_action( 'admin_enqueue_scripts', array($this,'scripts'), 999);
 
 		add_filter( 'mce_external_plugins',	array($this,'inlinelink_pre_45'));
 	}


### PR DESCRIPTION
Plugin assets could not be loaded due to wrong dir path creation. With this small change, it does not matter how the plugin folder is named to correctly include the assets.